### PR TITLE
Fix private extern crate error

### DIFF
--- a/build/epoxy_gen.rs
+++ b/build/epoxy_gen.rs
@@ -44,8 +44,8 @@ impl gl_generator::generators::Generator for EpoxyGenerator {
 fn write_header<W>(dest: &mut W) -> io::Result<()> where W: io::Write {
     writeln!(dest, r#"
         mod __gl_imports {{
-            extern crate gl_common;
-            extern crate libc;
+            pub extern crate gl_common;
+            pub extern crate libc;
             pub use std::mem;
             pub use std::ptr;
             pub use std::process::exit;


### PR DESCRIPTION
Not sure if this crate is abandoned or not, but it's going to be broken by an upcoming bugfix in rustc. This PR fixes the private crate error that wasn't caught by early versions of rustc.
See https://github.com/rust-lang/rust/issues/36886 and https://github.com/rust-lang/rust/pull/36894 for more details.
